### PR TITLE
Update action cards after renaming to alarm_sound

### DIFF
--- a/drivers/alarm_sound/driver.js
+++ b/drivers/alarm_sound/driver.js
@@ -39,9 +39,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 });
 
 Homey.manager('flow').on('action.sound_alarm', (callback, args) => {
-	Homey.manager('drivers').getDriver('alarmsound').capabilities.onoff.set(args.device, true, callback);
+	Homey.manager('drivers').getDriver('alarm_sound').capabilities.onoff.set(args.device, true, callback);
 });
 
 Homey.manager('flow').on('action.silence_alarm', (callback, args) => {
-	Homey.manager('drivers').getDriver('alarmsound').capabilities.onoff.set(args.device, false, callback);
+	Homey.manager('drivers').getDriver('alarm_sound').capabilities.onoff.set(args.device, false, callback);
 });


### PR DESCRIPTION
In the renaming of alarmsound to alarm_sound the action cards inside the driver.js were missed leading to app crashes
See. https://forum.athom.com/discussion/comment/50663/#Comment_50663